### PR TITLE
Added ability to set timeout value on per-test basis

### DIFF
--- a/agent/wptdriver/web_browser.cc
+++ b/agent/wptdriver/web_browser.cc
@@ -232,7 +232,7 @@ bool WebBrowser::RunAndWait() {
           ret = true;
           _status.Set(_T("Waiting up to %d seconds for the test to complete"), 
                       (_test._test_timeout / SECONDS_TO_MS) * 2);
-          DWORD wait_time = _test._test_timeout * 2;
+          DWORD wait_time = _test._test_timeout; //Stricter limit on this value 
           #ifdef DEBUG
           wait_time = INFINITE;
           #endif

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -106,6 +106,10 @@ bool WptSettings::Load(void) {
   _timeout = GetPrivateProfileInt(_T("WebPagetest"), _T("Time Limit"),
                                   _timeout, iniFile);
 
+  //Check if user-defined timeouts are enabled
+  _enableUserSetTimeout = GetPrivateProfileInt(_T("WebPagetest"), 
+    _T("EnableUserSetTimeout"), 0, iniFile) == 1;
+
   // load the Web Page Replay host
   if (GetPrivateProfileString(
       _T("WebPagetest"), _T("web_page_replay_host"), _T(""), buff,
@@ -121,6 +125,7 @@ bool WptSettings::Load(void) {
   }
 
   SetTestTimeout(_timeout * SECONDS_TO_MS);
+  SetEnableUserSetTimeout(_enableUserSetTimeout);
   if (_server.GetLength() && _location.GetLength())
     ret = true;
 

--- a/agent/wptdriver/wpt_settings.h
+++ b/agent/wptdriver/wpt_settings.h
@@ -105,6 +105,7 @@ public:
   CString _location;
   CString _key;
   DWORD   _timeout;
+  bool   _enableUserSetTimeout;
   DWORD   _startup_delay;
   DWORD   _polling_delay;
   int     _debug;

--- a/agent/wptdriver/wpt_test.h
+++ b/agent/wptdriver/wpt_test.h
@@ -176,6 +176,7 @@ public:
   CString _test_file;
   bool    _log_data;
   DWORD   _test_timeout;
+  bool    _has_test_timed_out;
   DWORD   _measurement_timeout;
   BYTE    _image_quality;
   bool    _png_screen_shot;
@@ -200,6 +201,8 @@ public:
   CStringA _test_error;
   CStringA _run_error;
   CString _custom_metrics;
+  DWORD   _script_timeout_multiplier;
+  bool   _enableUserSetTimeout;
   
   // current state
   int     _run;

--- a/agent/wpthook/shared_mem.cc
+++ b/agent/wpthook/shared_mem.cc
@@ -44,6 +44,7 @@ bool  shared_has_gpu = false;
 int   shared_result = -1;
 WCHAR shared_browser_exe[MAX_PATH] = {NULL};
 DWORD shared_browser_process_id = 0;
+bool  shared_enableUserSetTimeout = false;
 #pragma data_seg ()
 
 #pragma comment(linker,"/SECTION:.shared,RWS")
@@ -61,6 +62,11 @@ void WINAPI SetTestTimeout(DWORD timeout) {
   shared_test_timeout = timeout;
 }
 
+/*-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------*/
+void WINAPI SetEnableUserSetTimeout(bool userTimeout) {
+  shared_enableUserSetTimeout = userTimeout;
+}
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
 void WINAPI SetClearedCache(bool cleared_cache) {

--- a/agent/wpthook/shared_mem.h
+++ b/agent/wpthook/shared_mem.h
@@ -40,3 +40,4 @@ extern bool   shared_has_gpu;
 extern int    shared_result;
 extern WCHAR  shared_browser_exe[MAX_PATH];
 extern DWORD  shared_browser_process_id;
+extern bool   shared_enableUserSetTimeout;

--- a/agent/wpthook/test_state.h
+++ b/agent/wpthook/test_state.h
@@ -135,6 +135,9 @@ public:
   LARGE_INTEGER _title_time;
   SYSTEMTIME    _start_time;
 
+  //Timeout measurer
+  LARGE_INTEGER _timeout_start_time;
+
   LARGE_INTEGER _first_byte;
   int _doc_requests;
   int _requests;

--- a/agent/wpthook/wpt_test_hook.cc
+++ b/agent/wpthook/wpt_test_hook.cc
@@ -6,10 +6,11 @@
 
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
-WptTestHook::WptTestHook(WptHook& hook, TestState& test_state, DWORD timeout):
+WptTestHook::WptTestHook(WptHook& hook, TestState& test_state, DWORD timeout, bool enabledUserSetTimeout):
   hook_(hook)
   , test_state_(test_state) {
   _measurement_timeout = timeout;
+  _enableUserSetTimeout = enabledUserSetTimeout;
 }
 
 /*-----------------------------------------------------------------------------

--- a/agent/wpthook/wpt_test_hook.h
+++ b/agent/wpthook/wpt_test_hook.h
@@ -7,7 +7,7 @@ class TestState;
 class WptTestHook :
   public WptTest {
 public:
-  WptTestHook(WptHook& hook, TestState& test_state, DWORD timeout);
+  WptTestHook(WptHook& hook, TestState& test_state, DWORD timeout, bool enableUserSetTimeout);
   virtual ~WptTestHook(void);
   void LoadFromFile();
   virtual void ReportData();

--- a/agent/wpthook/wpthook.cc
+++ b/agent/wpthook/wpthook.cc
@@ -61,7 +61,7 @@ WptHook::WptHook(void):
   ,dns_(test_state_, test_)
   ,done_(false)
   ,test_server_(*this, test_, test_state_, requests_, dev_tools_, trace_)
-  ,test_(*this, test_state_, shared_test_timeout) {
+  ,test_(*this, test_state_, shared_test_timeout, shared_enableUserSetTimeout) {
 
   file_base_ = shared_results_file_base;
   background_thread_started_ = CreateEvent(NULL, TRUE, FALSE, NULL);

--- a/agent/wpthook/wpthook_dll.h
+++ b/agent/wpthook/wpthook_dll.h
@@ -38,6 +38,7 @@ extern "C" {
 _import void WINAPI InstallHook(void);
 _import void WINAPI SetResultsFileBase(const WCHAR * file_base);
 _import void WINAPI SetTestTimeout(DWORD timeout);
+_import void WINAPI SetEnableUserSetTimeout(bool enableUserSetTimeout);
 _import void WINAPI SetClearedCache(bool cleared_cache);
 _import bool WINAPI GetClearedCache();
 _import void WINAPI SetCurrentRun(DWORD run);

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -91,6 +91,7 @@
             $test['password'] = trim($req_password);
             $test['runs'] = (int)$req_runs;
             $test['fvonly'] = (int)$req_fvonly;
+            $test['timeout'] = (int)$req_timeout;
             $test['connections'] = (int)$req_connections;
             $test['private'] = $req_private;
             $test['web10'] = $req_web10;
@@ -1791,6 +1792,7 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
         // write out the ini file
         $testInfo = "[test]\r\n";
         $testInfo .= "fvonly={$test['fvonly']}\r\n";
+        $testInfo .= "timeout={$test['timeout']}\r\n";
         $resultRuns = $test['runs'] - $test['discard'];
         $testInfo .= "runs=$resultRuns\r\n";
         $testInfo .= "location=\"{$test['locationText']}\"\r\n";
@@ -1844,6 +1846,8 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
                 $testFile .= "\r\nDOMElement={$test['domElement']}";
             if( $test['fvonly'] )
                 $testFile .= "\r\nfvonly=1";
+            if( $test['timeout'] )
+                $testFile .= "\r\ntimeout={$test['timeout']}";
             if( $test['web10'] )
                 $testFile .= "\r\nweb10=1";
             if( $test['ignoreSSL'] )


### PR DESCRIPTION
This allows users to set a query parmater "timeout=%d" in runtest.php,
where %d is the amount of time to test should be allowed to run for
before web page test force quits the test.

The results of this test up to this point of timeout will be recorded.
If the test times out, the result code for the step that that timeout
occured on will be 99998.

Manual Testing:
-Verified new code has no effect when EnableUserSetTimeout is not included
in wptdriver.ini file
-Verified test times out when timit limit is reached
-Verified test does not timeout when time limit is not reached
-Verified negative timeout values are disgarded
-Verified that partial test results are returned on multi-step test run
