### PR TITLE
Set the base page URL correctly when running webdriver script

### DIFF
--- a/agent/browser/chrome/extension/release/wpt/allTests.js
+++ b/agent/browser/chrome/extension/release/wpt/allTests.js
@@ -5518,8 +5518,10 @@ window.addEventListener('load', function() {
   var fixedViewport = 0;
   if (document.querySelector("meta[name=viewport]"))
     fixedViewport = 1;
+  var navigatedUrl = document.URL;
   chrome.extension.sendRequest({'message': 'wptLoad',
                                 'fixedViewport': fixedViewport,
+                                'navigatedUrl': navigatedUrl,
                                 'timestamp': timestamp}, function(response) {});
 }, false);
 

--- a/agent/browser/chrome/extension/release/wpt/background.js
+++ b/agent/browser/chrome/extension/release/wpt/background.js
@@ -14983,7 +14983,8 @@ chrome.extension.onRequest.addListener(
     else if (request.message == 'wptLoad') {
       wptSendEvent('load', 
                    '?timestamp=' + request.timestamp + 
-                   '&fixedViewport=' + request.fixedViewport);
+                   '&fixedViewport=' + request.fixedViewport +
+                   '&url=' + encodeURIComponent(request.navigatedUrl));
     }
     else if (request.message == 'wptBeforeUnload' && g_webdriver_mode) {
       // We are about to move to a new page. Let the hook know so that it can prepare for the next step.

--- a/agent/browser/chrome/extension/release/wpt/script.js
+++ b/agent/browser/chrome/extension/release/wpt/script.js
@@ -178,8 +178,10 @@ window.addEventListener('load', function() {
   var fixedViewport = 0;
   if (document.querySelector("meta[name=viewport]"))
     fixedViewport = 1;
+  var navigatedUrl = document.URL;
   chrome.extension.sendRequest({'message': 'wptLoad',
                                 'fixedViewport': fixedViewport,
+                                'navigatedUrl': navigatedUrl,
                                 'timestamp': timestamp}, function(response) {});
 }, false);
 

--- a/agent/browser/chrome/extension/wpt/background.js
+++ b/agent/browser/chrome/extension/wpt/background.js
@@ -457,7 +457,8 @@ chrome.extension.onRequest.addListener(
     else if (request.message == 'wptLoad') {
       wptSendEvent('load', 
                    '?timestamp=' + request.timestamp + 
-                   '&fixedViewport=' + request.fixedViewport);
+                   '&fixedViewport=' + request.fixedViewport +
+                   '&url=' + encodeURIComponent(request.navigatedUrl));
     }
     else if (request.message == 'wptBeforeUnload' && g_webdriver_mode) {
       // We are about to move to a new page. Let the hook know so that it can prepare for the next step.

--- a/agent/browser/chrome/extension/wpt/script.js
+++ b/agent/browser/chrome/extension/wpt/script.js
@@ -178,8 +178,10 @@ window.addEventListener('load', function() {
   var fixedViewport = 0;
   if (document.querySelector("meta[name=viewport]"))
     fixedViewport = 1;
+  var navigatedUrl = document.URL;
   chrome.extension.sendRequest({'message': 'wptLoad',
                                 'fixedViewport': fixedViewport,
+                                'navigatedUrl': navigatedUrl,
                                 'timestamp': timestamp}, function(response) {});
 }, false);
 

--- a/agent/browser/firefox/extension/chrome/content/overlay.js
+++ b/agent/browser/firefox/extension/chrome/content/overlay.js
@@ -224,7 +224,7 @@ wpt.moz.main.onLoad = function(win) {
     fixedViewport = 1;
   var domCount = win.document.getElementsByTagName("*").length;
   wpt.moz.main.sendEventToDriver_('load?fixedViewport=' +
-      fixedViewport + '&domCount=' + domCount);
+      fixedViewport + '&domCount=' + domCount + '&url='+ encodeURIComponent(win.document.URL));
   if (g_webdriver_mode) {
     runSoon(function () {
       wpt.moz.main.collectStats('', function () {

--- a/agent/wpthook/test_server.cc
+++ b/agent/wpthook/test_server.cc
@@ -210,6 +210,10 @@ void TestServer::MongooseCallback(enum mg_event event,
       if (GetDwordParam(request_info->query_string, "domCount", dom_count) &&
           dom_count)
         test_state_._dom_element_count = dom_count;
+      CString url = GetUnescapedParam(request_info->query_string, "url");
+      if (!url.IsEmpty()) {
+        test_._navigated_url = url;
+      }
       // Browsers may get "/event/window_timing" to set "onload" time.
       DWORD load_time = 0;
       GetDwordParam(request_info->query_string, "timestamp", load_time);


### PR DESCRIPTION
When running in webdriver mode, the hook has no obvious way of identifying
the base page URL. To address this, pass the base page URL as part of the
load event that is sent by the browser extension.
