### PR TITLE
New option to add custom headers to http requests

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -393,6 +393,13 @@ $loc = ParseLocations($locations);
                                         </label>
                                         <input id="tester" type="text" class="text" name="tester" value="">
                                     </li>
+                                    <li>
+                                        <label for="customHeaders">
+                                            Custom headers<br>
+                                            <small>Add custom headers to all network requests emitted from the browser</small>
+                                        </label>
+                                        <textarea id="customHeaders" type="text" class="text" name="customHeaders" value=""></textarea>
+                                    </li>
                                 </ul>
                             </div>
                             <div id="advanced-chrome" class="test_subbox ui-tabs-hide">

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -90,6 +90,7 @@
             $test['domElement'] = trim($req_domelement);
             $test['login'] = trim($req_login);
             $test['password'] = trim($req_password);
+            $test['customHeaders'] = trim($req_customHeaders);
             $test['runs'] = (int)$req_runs;
             $test['fvonly'] = (int)$req_fvonly;
             $test['timeout'] = (int)$req_timeout;
@@ -2305,6 +2306,17 @@ function ProcessTestScript($url, &$test) {
     if (!isset($script) || !strlen($script))
       $script = "navigate\t$url";
     $script = "addHeader\t$header\r\n" . $script;
+  }
+  // Add custom headers
+  if (strlen($test['customHeaders'])) {
+    if (!isset($script) || !strlen($script))
+      $script = "navigate\t$url";
+    $headers = preg_split("/\r\n|\n|\r/", $test['customHeaders']);
+    $headerCommands = "";
+    foreach ($headers as $header) {
+      $headerCommands = $headerCommands . "addHeader\t".$header."\r\n";
+    }
+    $script = $headerCommands . $script;
   }
   return $script;
 }


### PR DESCRIPTION
Custom headers are useful to control features of other testing or monitoring
platforms, such as enabling snapshots on AppDynamic's APM. Other use cases
for custom headers include authentication, setting cookies (for example, for
sessions), control backend features (cache policies,...), ...

The same effect can be achieved with scripts. This is a convenience feature that we are adding because our (soon to be released) integration with WebDriver disables custom scripts per say.
