### PR TITLE
Fix missing resources across page loads

### DIFF
--- a/agent/wpthook/test_server.h
+++ b/agent/wpthook/test_server.h
@@ -78,4 +78,6 @@ private:
   CString GetPostBody(struct mg_connection *conn,
                       const struct mg_request_info *request_info);
   bool OkToStart();
+
+  void SaveResultsIfNeeded();
 };

--- a/agent/wpthook/test_state.h
+++ b/agent/wpthook/test_state.h
@@ -96,6 +96,7 @@ public:
   void SetFirstPaint(DWORD first_paint);
   void OnLoad(); // browsers either call this or SetLoadEvent
   void OnStatusMessage(CString status);
+  void Done(bool force = false);
   bool IsDone();
   void GrabVideoFrame(bool force = false);
   void CollectData();
@@ -206,7 +207,6 @@ private:
 
   CRITICAL_SECTION  _data_cs;
 
-  void Done(bool force = false);
   void CollectSystemStats(LARGE_INTEGER &now);
   void CheckTitle();
   void FindViewport(bool force = false);

--- a/agent/wpthook/wpthook.h
+++ b/agent/wpthook/wpthook.h
@@ -64,10 +64,20 @@ public:
   void OnNavigateComplete();
   void Report();
   void OnReport();
+  void ResetHookReady();
   void SetHookReady();
   bool IsHookReady();
   void OnWebDriverDone();
   bool IsWebDriverDone();
+  void SetNewPageLoad();
+  bool IsNewPageLoad();
+  void Save();
+  void Cleanup();
+  void AsyncShutdown();
+  void ShutdownNow();
+  void OnWindowTimingReceived();
+  bool IsWindowTimingReceived();
+
 private:
   CWsHook   winsock_hook_;
   NsprHook  nspr_hook_;
@@ -81,7 +91,10 @@ private:
   bool      reported_;
   bool      hook_ready_;
   bool      webdriver_done_;
+  bool      new_page_load_;
+  bool      window_timing_received_;
   UINT      report_message_;
+  UINT      shutdown_message_;
 
   // winsock event tracking
   TrackDns      dns_;


### PR DESCRIPTION
- On a new webdriver action, create a state.
- On a before_unload (indicative of new page load), set hook_ready to
      false. This will prevent future webdriver actions until the hook
      has saved the current state.
- Once all the timings (window_timing request) are received, set the
      hook_ready to true.
- On the next webdriver action, check if there was a page load. If so,
      save the current state. Else, discard the current state. Also,
      create a new state for future webdriver commands.
