### PR TITLE
Fix: custom headers don't work with webdriver scripts

### DIFF
--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -167,6 +167,7 @@ void WptTest::Reset(void) {
 -----------------------------------------------------------------------------*/
 bool WptTest::Load(CString& test) {
   bool ret = false;
+  bool reading_headers = false;
 
   WptTrace(loglevel::kFunction, _T("WptTest::Load()\n"));
 
@@ -177,7 +178,7 @@ bool WptTest::Load(CString& test) {
   CString line = test.Tokenize(_T("\r\n"), linePos);
   while (!done && linePos >= 0) {
     int keyEnd = line.Find('=');
-    if (keyEnd > 0) {
+    if (!reading_headers && keyEnd > 0) {
       CString key = line.Left(keyEnd).Trim();
       CString value = line.Mid(keyEnd + 1);
       if (key.GetLength()) {
@@ -307,11 +308,23 @@ bool WptTest::Load(CString& test) {
           _webdriver_args = value.Trim();
         }
       }
-    } else if (!line.Trim().CompareNoCase(_T("[Script]"))) {
+    } else if (!reading_headers && !line.Trim().CompareNoCase(_T("[Script]"))) {
       // grab the rest of the response as the script
       _script = test.Mid(linePos).Trim();
       done = true;
-    }
+    } else if (!line.Trim().CompareNoCase(_T("[StartHeaders]"))) {
+      reading_headers = true;
+    } else if (!line.Trim().CompareNoCase(_T("[EndHeaders]"))) {
+      reading_headers = false;
+    } else if (reading_headers) {
+      int pos = line.Find(_T(':'));
+      if (pos > 0) {
+        CStringA tag = CT2A(line.Left(pos).Trim());
+        CStringA value = CT2A(line.Mid(pos + 1).Trim());
+        HttpHeaderValue header(tag, value, CStringA());
+        _add_headers.AddTail(header);
+      }
+    } 
 
     line = test.Tokenize(_T("\r\n"), linePos);
   }

--- a/www/runtest.php
+++ b/www/runtest.php
@@ -2011,6 +2011,17 @@ function CreateTest(&$test, $url, $batch = 0, $batch_locations = 0)
                 $testFile .= "customMetric=$name:$code\r\n";
             }
 
+            // Add Custom Headers
+            if ($test['script'] && isset($test['webdriver']) && $test['webdriver']) {
+              if (strlen($test['customHeaders'])) {
+                $headers = preg_split("/\r\n|\n|\r/", $test['customHeaders']);
+                $testFile .= "\r\n[StartHeaders]\r\n";
+                foreach ($headers as $header) {
+                  $testFile .= $header . "\r\n";
+                }
+                $testFile .= "[EndHeaders]\r\n";
+              }
+            }
             if( !SubmitUrl($testId, $testFile, $test, $url) )
                 $testId = null;
         }
@@ -2352,15 +2363,17 @@ function ProcessTestScript($url, &$test) {
     $script = "addHeader\t$header\r\n" . $script;
   }
   // Add custom headers
-  if (strlen($test['customHeaders'])) {
-    if (!isset($script) || !strlen($script))
-      $script = "navigate\t$url";
-    $headers = preg_split("/\r\n|\n|\r/", $test['customHeaders']);
-    $headerCommands = "";
-    foreach ($headers as $header) {
-      $headerCommands = $headerCommands . "addHeader\t".$header."\r\n";
+  if (!isset($test['webdriver']) || $test['webdriver'] == '') {
+    if (strlen($test['customHeaders'])) {
+      if (!isset($script) || !strlen($script))
+        $script = "navigate\t$url";
+      $headers = preg_split("/\r\n|\n|\r/", $test['customHeaders']);
+      $headerCommands = "";
+      foreach ($headers as $header) {
+        $headerCommands = $headerCommands . "addHeader\t".$header."\r\n";
+      }
+      $script = $headerCommands . $script;
     }
-    $script = $headerCommands . $script;
   }
   return $script;
 }


### PR DESCRIPTION
Note: this fix only works for IE and firefox. A fix for chrome is coming soon.
