### PR TITLE
Increase timeout to 60 seconds for the browser to start

### DIFF
--- a/agent/wptdriver/globals.cc
+++ b/agent/wptdriver/globals.cc
@@ -8,5 +8,5 @@ const TCHAR * FLASH_CACHE_DIR =
                         _T("Macromedia\\Flash Player\\#SharedObjects");
 const TCHAR * SILVERLIGHT_CACHE_DIR = _T("Microsoft\\Silverlight");
 
-int const BROWSER_STARTED_EVENT_TIMEOUT = 20000;
+int const BROWSER_STARTED_EVENT_TIMEOUT = 60000;
 int const RESULTS_PROCESSING_GRACE_PERIOD = 30000;


### PR DESCRIPTION
20 seconds is too low considering the plink overhead and
the time spent on waiting for the browser to cool down.
