### PR TITLE
Fix bug causing extra steps to appear

### DIFF
--- a/www/devtools.inc.php
+++ b/www/devtools.inc.php
@@ -394,10 +394,12 @@ function GetDevToolsRequests($testPath, $run, $cached, &$requests, &$pageData, $
             for ($i = 0; $i < count($events); $i++) {
                 $stepEvents = $events[$i];
                 $stepPageData = null;
-                $stepRequests = null;
+                $stepPageRequests = null;
                 $ok = ProcessDevToolsEvents($stepEvents, $stepPageData, $stepPageRequests, $i);
-                $requests[] = $stepPageRequests;
-                $pageData[] = $stepPageData;
+                if ($ok || isset($stepPageData['URL'])) {
+                    $requests[] = $stepPageRequests;
+                    $pageData[] = $stepPageData;
+                }
             }
         } else {
             $ok = ProcessDevToolsEvents($events, $pageData, $requests);


### PR DESCRIPTION
When the user navigates to a non existant page, Chrome loads the error frame.
This frame does not issue any network requests and has no URL, as such it should
not appear as a distinctive step.
