### PR TITLE
Fix: non-webdriver measurements fails on IE

### DIFF
--- a/agent/browser/ie/wptbho/wpt.cc
+++ b/agent/browser/ie/wptbho/wpt.cc
@@ -254,8 +254,8 @@ void Wpt::OnLoad() {
 }
 
 void Wpt::OnBeforeNavigate() {
+  _timings_reported = false;
   if (_active && _webdriver_mode) {
-    _timings_reported = false;
     AtlTrace(_T("[wptbho] - Wpt::OnBeforeNavigate()"));
     _wpt_interface.OnBeforeNavigate();
   }


### PR DESCRIPTION
_timings_reported flag was incorrectly maintained in non-webdriver mode
