### PR TITLE
Fix wrong navigation timing for IE

### DIFF
--- a/agent/browser/ie/wptbho/wpt.cc
+++ b/agent/browser/ie/wptbho/wpt.cc
@@ -253,7 +253,6 @@ void Wpt::OnLoad() {
 }
 
 void Wpt::OnBeforeNavigate() {
-  _timings_reported = false;
   if (_active && _webdriver_mode) {
     AtlTrace(_T("[wptbho] - Wpt::OnBeforeNavigate()"));
     _wpt_interface.OnBeforeNavigate();
@@ -1119,10 +1118,6 @@ DWORD Wpt::CountDOMElements(CComQIPtr<IHTMLDocument2> &document) {
   Collect the stats at the end of a test
 -----------------------------------------------------------------------------*/
 void Wpt::CollectStats(CString custom_metrics) {
-  if (_timings_reported) {
-    return;
-  }
-  _timings_reported = true;
   AtlTrace(_T("[wptbho] - Wpt::CollectStats()"));
   if (_web_browser) {
     CComPtr<IDispatch> dispatch;

--- a/agent/browser/ie/wptbho/wpt.h
+++ b/agent/browser/ie/wptbho/wpt.h
@@ -33,7 +33,6 @@ private:
   HWND          _message_window;
   bool          _navigating;
   bool          _must_exit;
-  bool          _timings_reported;
   HANDLE        _task_thread;
   bool          _processing_task;
   WptTask       _task;


### PR DESCRIPTION
Navigation timing were propagated too early with the previous
page timing info. As a result, load event timing and dom content loaded
timing were negative.
