### PR TITLE
Change BHO to rely on performance timing

### DIFF
--- a/agent/browser/ie/wptbho/wpt.h
+++ b/agent/browser/ie/wptbho/wpt.h
@@ -38,6 +38,7 @@ private:
   WptTask       _task;
   int           _exec_count;
   bool          _webdriver_mode;
+  LONGLONG      _last_load_event_end;
 
   typedef enum{
     equal = 0,
@@ -67,6 +68,10 @@ private:
   void  SubmitForm(CString target);
 
   // support routines
+  CString GetParam(const CString query_string, const CString key) const;
+  bool GetLongLongParam(const CString query_string, const CString key,
+    LONGLONG& value) const;
+  LONGLONG	GetLoadEventEnd();
   DWORD CountDOMElements(CComQIPtr<IHTMLDocument2> &document);
   void  ExpireCacheEntry(INTERNET_CACHE_ENTRY_INFO * info, DWORD seconds);
   void  CheckBrowserState();

--- a/agent/wpthook/test_server.cc
+++ b/agent/wpthook/test_server.cc
@@ -239,41 +239,35 @@ void TestServer::MongooseCallback(enum mg_event event,
     } else if (strcmp(request_info->uri, "/event/window_timing") == 0) {
 
       LONGLONG start = 0LL;
-      GetLongLongParam(request_info->query_string, "domContentLoadedEventStart",
-                    start);
+      GetLongLongParam(request_info->query_string, "loadEventStart", start);
       LONGLONG end = 0LL;
-      GetLongLongParam(request_info->query_string, "domContentLoadedEventEnd",
-                    end);
+      GetLongLongParam(request_info->query_string, "loadEventEnd", end);
       if (start < 0LL)
         start = 0LL;
       if (end < 0LL)
         end = 0LL;
 
-      // When running an IE measurement, this endpoint will be called several times.
-      // We need to make sure we are setting the hook ready only when we receive new
-      // page metrics information. By doing so, we ensure we are on a new page and not
-      // receiving timing info from the previous page.
-      if (start != test_state_._dom_content_loaded_event_start) {
-        hook_.SetDomContentLoadedEvent(start, end);
-        start = 0LL;
-        GetLongLongParam(request_info->query_string, "loadEventStart", start);
-        end = 0LL;
-        GetLongLongParam(request_info->query_string, "loadEventEnd", end);
-        if (start < 0LL)
-          start = 0LL;
-        if (end < 0LL)
-          end = 0LL;
+      hook_.SetLoadEvent(start, end);
 
-        hook_.SetLoadEvent(start, end);
-        LONGLONG first_paint = 0;
-        GetLongLongParam(request_info->query_string, "msFirstPaint", first_paint);
-        if (first_paint < 0LL)
-          first_paint = 0LL;
-        hook_.SetFirstPaint(first_paint);
-        hook_.OnWindowTimingReceived();
-        hook_.SetHookReady();
-      }
-     
+      start = 0LL;
+      GetLongLongParam(request_info->query_string, "domContentLoadedEventStart",
+        start);
+      end = 0LL;
+      GetLongLongParam(request_info->query_string, "domContentLoadedEventEnd",
+        end);
+      if (start < 0LL)
+        start = 0LL;
+      if (end < 0LL)
+        end = 0LL;
+        
+      hook_.SetDomContentLoadedEvent(start, end);
+      LONGLONG first_paint = 0;
+      GetLongLongParam(request_info->query_string, "msFirstPaint", first_paint);
+      if (first_paint < 0LL)
+        first_paint = 0LL;
+      hook_.SetFirstPaint(first_paint);
+      hook_.OnWindowTimingReceived();
+      hook_.SetHookReady();
       SendResponse(conn, request_info, RESPONSE_OK, RESPONSE_OK_STR, "");
     } else if (strcmp(request_info->uri, "/event/navigate") == 0) {
       hook_.OnNavigate();


### PR DESCRIPTION
This PR removes the use of IE ready state for collecting statistics since it is known to be problematic on pages with ever loading iframes.
Instead of IE ready state, the performance timing is polled until it's available.

Tested on:
- [x] A normal page
- [x] A page with error
- [x] A multi-step page
- [x] A multi-step page with an error
- [x] URL measurement
