### PR TITLE
Use a combination of ready state and onload to collect stats

### DIFF
--- a/agent/browser/ie/wptbho/wpt.h
+++ b/agent/browser/ie/wptbho/wpt.h
@@ -39,6 +39,7 @@ private:
   int           _exec_count;
   bool          _webdriver_mode;
   LONGLONG      _last_load_event_end;
+  int           _onload_wait;
 
   typedef enum{
     equal = 0,


### PR DESCRIPTION
There is a bug in IE10 that prevent loadEventStart and loadEventEnd to be populated in performance.timings. This creates a deadlock where the page is never marked as stable.

This PR changes the stability detection to use ready state "complete" and loadEventEnd. In the spec, ready state "complete" will happen just before the onload event is propagated. This PR will wait up to 20s for the onload to execute, then it will bail out.
