### PR TITLE
Clean up and workaround IE10 navtime bug

### DIFF
--- a/agent/browser/ie/wptbho/wpt.h
+++ b/agent/browser/ie/wptbho/wpt.h
@@ -16,9 +16,9 @@ public:
   bool OnMessage(UINT message, WPARAM wParam, LPARAM lParam);
 
   // browser events
-  void  OnLoad();
+  void  OnDocumentComplete();
   void  OnBeforeNavigate();
-  void  OnNavigate();
+  void  OnNavigateComplete(CString url);
   void  OnNavigateError(DWORD error);
   void  OnTitle(CString title);
   void  OnStatus(CString status);
@@ -76,6 +76,8 @@ private:
   DWORD CountDOMElements(CComQIPtr<IHTMLDocument2> &document);
   void  ExpireCacheEntry(INTERNET_CACHE_ENTRY_INFO * info, DWORD seconds);
   void  CheckBrowserState();
+  void  MarkLoadEventStart();
   CString JSONEscape(CString src);
   CString GetCustomMetric(CString code);
+  LONGLONG GetLongLong(LPOLESTR fnc);
 };

--- a/agent/browser/ie/wptbho/wptbho.cc
+++ b/agent/browser/ie/wptbho/wptbho.cc
@@ -65,16 +65,16 @@ STDMETHODIMP_(void) WptBHO::OnBeforeNavigate2(IDispatch *pDisp, VARIANT * vUrl,
   CString url;
   if (vUrl)
     url = *vUrl;
-  AtlTrace(_T("[WptBHO] OnBeforeNavigate2 - %s"), url);
   CComPtr<IUnknown> unknown_browser = _web_browser;
   CComPtr<IUnknown> unknown_frame = pDisp;
   if (unknown_browser && unknown_frame && unknown_browser == unknown_frame) {
+    AtlTrace(_T("[WptBHO] OnBeforeNavigate2 - %s"), url);
     _wpt.OnBeforeNavigate();
-    _wpt.OnNavigate();
   }
 }
 
 /*-----------------------------------------------------------------------------
+Called when READY_STATE is set to complete
 -----------------------------------------------------------------------------*/
 STDMETHODIMP_(void) WptBHO::OnDocumentComplete(IDispatch *pDisp, 
             VARIANT * vUrl) {
@@ -85,12 +85,29 @@ STDMETHODIMP_(void) WptBHO::OnDocumentComplete(IDispatch *pDisp,
   CComPtr<IUnknown> unknown_browser = _web_browser;
   CComPtr<IUnknown> unknown_frame = pDisp;
   if (unknown_browser && unknown_frame && unknown_browser == unknown_frame) {
-    _wpt.OnLoad();
+    _wpt.OnDocumentComplete();
     if (!url.CompareNoCase(_T("about:blank"))) {
       _wpt.Install(_web_browser);
     } else if(!url.CompareNoCase(_T("http://127.0.0.1:8888/blank.html"))) {
       _wpt.Start();
     }
+  }
+}
+
+/*-----------------------------------------------------------------------------
+Called when navigation is done
+-----------------------------------------------------------------------------*/
+STDMETHODIMP_(void) WptBHO::OnNavigateComplete(IDispatch *pDisp,
+  VARIANT * vUrl) {
+  CString url;
+  if (vUrl)
+    url = *vUrl;
+
+  CComPtr<IUnknown> unknown_browser = _web_browser;
+  CComPtr<IUnknown> unknown_frame = pDisp;
+  if (unknown_browser && unknown_frame && unknown_browser == unknown_frame) {
+    AtlTrace(_T("[WptBHO] OnNavigateComplete - %s"), url);
+    _wpt.OnNavigateComplete(url);
   }
 }
 
@@ -128,7 +145,7 @@ STDMETHODIMP_(void) WptBHO::OnNavigateError(IDispatch *pDisp, VARIANT *vUrl,
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
 STDMETHODIMP_(void) WptBHO::OnQuit(VOID) {
-  _wpt.OnLoad();
+  _wpt.OnDocumentComplete();
 }
 
 /*-----------------------------------------------------------------------------

--- a/agent/browser/ie/wptbho/wptbho.h
+++ b/agent/browser/ie/wptbho/wptbho.h
@@ -37,7 +37,8 @@ END_COM_MAP()
   DECLARE_PROTECT_FINAL_CONSTRUCT()
   BEGIN_SINK_MAP(WptBHO)
     SINK_ENTRY_EX(1, DIID_DWebBrowserEvents2, DISPID_BEFORENAVIGATE2, OnBeforeNavigate2 )
-    SINK_ENTRY_EX(1, DIID_DWebBrowserEvents2, DISPID_DOCUMENTCOMPLETE, OnDocumentComplete )
+    SINK_ENTRY_EX(1, DIID_DWebBrowserEvents2, DISPID_NAVIGATECOMPLETE2, OnNavigateComplete)
+    SINK_ENTRY_EX(1, DIID_DWebBrowserEvents2, DISPID_DOCUMENTCOMPLETE, OnDocumentComplete)
     SINK_ENTRY_EX(1, DIID_DWebBrowserEvents2, DISPID_NAVIGATEERROR, OnNavigateError )
     SINK_ENTRY_EX(1, DIID_DWebBrowserEvents2, DISPID_NEWWINDOW2, OnNewWindow2 )
     SINK_ENTRY_EX(1, DIID_DWebBrowserEvents2, DISPID_NEWWINDOW3, OnNewWindow3 )
@@ -58,7 +59,8 @@ END_COM_MAP()
   STDMETHOD_(void,OnBeforeNavigate2)( IDispatch *pDisp, VARIANT * vUrl, 
               VARIANT * Flags, VARIANT * TargetFrameName, VARIANT * PostData, 
               VARIANT * Headers, VARIANT_BOOL * Cancel );
-  STDMETHOD_(void,OnDocumentComplete)( IDispatch *pDisp, VARIANT * vUrl );
+  STDMETHOD_(void, OnNavigateComplete)(IDispatch *pDisp, VARIANT * vUrl);
+  STDMETHOD_(void, OnDocumentComplete)(IDispatch *pDisp, VARIANT * vUrl);
   STDMETHOD_(void,OnNavigateError)( IDispatch *pDisp, VARIANT *vUrl, 
               VARIANT *TargetFrameName, VARIANT *StatusCode, 
               VARIANT_BOOL *Cancel);


### PR DESCRIPTION
IE10 has a bug where `loadEventStart` and `loadEventEnd` are not reported in `performance.timing` object.

To workaround this limitation, this PR injects JS to measure load event `start` and `end` marks. Knowing that the `load` event is triggered right after ready state is set to `complete`, the `loadEventStart` is set in `OnDocumentComplete` callback and `loadEventEnd` is set just after the `onload` handler (in a timer, to make sure all `onload` handlers are executed first).
