### PR TITLE
Enable HTTP basic auth for on demand measurements in FireFox

### DIFF
--- a/agent/wptdriver/web_browser.cc
+++ b/agent/wptdriver/web_browser.cc
@@ -356,6 +356,8 @@ void WebBrowser::ConfigureFirefoxPrefs() {
         }
       }
     }
+    // Enable http basic auth using http://user:pass@domain.com
+    user_prefs += "user_pref(\"network.http.phishy-userpass-length\", 255);\r\n";
     if (_test._noscript) {
       user_prefs += "user_pref(\"javascript.enabled\", false);\r\n";
     }


### PR DESCRIPTION
By default, Firefox prompts the user for confirmation when navigating
to URLs with embedded username and password (http://user:pass@domain.com).
This patch tells Firefox to allow these URLs by default
