### PR TITLE
Wait up to 2min to start the measurement

### DIFF
--- a/agent/wptdriver/web_browser.cc
+++ b/agent/wptdriver/web_browser.cc
@@ -138,7 +138,7 @@ bool WebBrowser::RunAndWait() {
                           0, NULL, NULL, &si, &pi)) {
           CloseHandle(pi.hThread);
           CloseHandle(pi.hProcess);
-          if (WaitForSingleObject(_browser_started_event, 60000) ==
+          if (WaitForSingleObject(_browser_started_event, 120000) ==
               WAIT_OBJECT_0) {
             DWORD pid = GetBrowserProcessId();
             if (pid) {


### PR DESCRIPTION
Given the added complexity of the infrastructure, on some slow node, 60s isn't enough to start the measurement.

This PR increase the startup time to 120s.
