### PR TITLE
Add small delay before reporting results

### DIFF
--- a/agent/wpthook/wpthook.h
+++ b/agent/wpthook/wpthook.h
@@ -93,7 +93,6 @@ private:
   bool      webdriver_done_;
   bool      new_page_load_;
   bool      window_timing_received_;
-  UINT      report_message_;
   UINT      shutdown_message_;
 
   // winsock event tracking


### PR DESCRIPTION
This fixes a race condition where the browser does not have enough
time to report the statistics between the "CollectStats" command and
the "ReportData" command, leading to measurements missing some metrics
