### PR TITLE
Provide ability to perform maintenance on agents

### DIFF
--- a/agent/wptdriver/util.cc
+++ b/agent/wptdriver/util.cc
@@ -837,20 +837,3 @@ void ConstructCmdLine(CString& exe, CAtlArray<CString>& options,
     cmdLine.Append(_T(" ") + prefix + options[i]);
   }
 }
-
-LPTSTR GetErrorDetail(DWORD error) {
-  LPTSTR error_text = NULL;
-
-  FormatMessage(
-    FORMAT_MESSAGE_FROM_SYSTEM
-    | FORMAT_MESSAGE_ALLOCATE_BUFFER
-    | FORMAT_MESSAGE_IGNORE_INSERTS,
-    NULL,
-    error,
-    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-    (LPTSTR)&error_text,
-    0,
-    NULL);
-
-  return error_text;
-}

--- a/agent/wptdriver/util.h
+++ b/agent/wptdriver/util.h
@@ -91,4 +91,3 @@ void Reboot();
 DWORD GetCapabilities(void);
 void ConstructCmdLine(CString& exe, CAtlArray<CString>& options,
   CString& prefix, CString& cmdLine);
-LPTSTR GetErrorDetail(DWORD error);

--- a/agent/wptdriver/wpt_driver_core.h
+++ b/agent/wptdriver/wpt_driver_core.h
@@ -75,4 +75,5 @@ private:
   bool Startup();
   LPTSTR GetAppInitString(LPCTSTR new_dll);
   bool NeedsReboot();
+  bool NeedsMaintenance();
 };


### PR DESCRIPTION
If a file by name "appdynamics-maintenance.dat" is present in
%LOCALAPPDATA%, wptdriver will shutdown (after completing an ongoing
test, but before starting another one).

This makes it easy for Chef recipes to perform controller maintenance
without affecting ongoing tests.
