### PR TITLE
Don't close browser from hook in scripted measurements

### DIFF
--- a/agent/wpthook/test_server.cc
+++ b/agent/wpthook/test_server.cc
@@ -200,7 +200,6 @@ void TestServer::MongooseCallback(enum mg_event event,
     } else if (strcmp(request_info->uri, "/event/webdriver_done") == 0) {
       SaveResults();
       hook_.Cleanup();
-      hook_.AsyncShutdown();
       SendResponse(conn, request_info, RESPONSE_OK, RESPONSE_OK_STR, "");
     } else if (strcmp(request_info->uri, "/event/before_unload") == 0) {
       hook_.SetNewPageLoad();

--- a/agent/wpthook/wpthook.cc
+++ b/agent/wpthook/wpthook.cc
@@ -279,15 +279,6 @@ void WptHook::ShutdownNow() {
   WptTrace(loglevel::kTrace, _T("[wpthook] Leaving ShutdownNow()"));
 }
 
-void WptHook::AsyncShutdown() {
-  WptTrace(loglevel::kTrace, _T("[wpthook] - In AsyncShutdown"));
-  if (message_window_ && shutdown_message_) {
-    WptTrace(loglevel::kTrace, _T("[wpthook] - Posting shutdown message"));
-    ::PostMessage(message_window_, shutdown_message_, 0, 0);
-    WptTrace(loglevel::kTrace, _T("[wpthook] - Done posting shutdown message"));
-  }
-  WptTrace(loglevel::kTrace, _T("[wpthook] - Leaving AsyncShutdown"));
-}
 
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/

--- a/agent/wpthook/wpthook.h
+++ b/agent/wpthook/wpthook.h
@@ -73,7 +73,6 @@ public:
   bool IsNewPageLoad();
   void Save(bool merge = false);
   void Cleanup();
-  void AsyncShutdown();
   void ShutdownNow();
   void OnWindowTimingReceived();
   bool IsWindowTimingReceived();


### PR DESCRIPTION
IEDriverServer get confused if the browser is closed when it tries
to delete session, resulting in a wait of 30s.

Since the browser is closed by the script, we don't need the hook to close the browser. In case the script fails to close the browser, the wpt driver will close it and if this fails too, the wpt driver will close all browsers before starting a new measurement.
