### PR TITLE
Unregister hooks when measurement over

### DIFF
--- a/agent/browser/chrome/extension/release/wpt/allTests.js
+++ b/agent/browser/chrome/extension/release/wpt/allTests.js
@@ -5461,9 +5461,7 @@ wpt.contentScript.collectStats_ = function(customMetrics) {
   var timingRequest = { 'message': 'wptWindowTiming' };
   function addTime(name) {
     if (window.performance.timing[name] > 0) {
-      timingRequest[name] = Math.max(0, (
-        window.performance.timing[name] -
-        window.performance.timing['navigationStart']));
+      timingRequest[name] = window.performance.timing[name];
     }
   };
   addTime('domContentLoadedEventStart');

--- a/agent/browser/chrome/extension/release/wpt/background.js
+++ b/agent/browser/chrome/extension/release/wpt/background.js
@@ -14027,7 +14027,7 @@ wpt.chromeDebugger.StartTrace = function() {
       traceCategories = '*';
     else
       traceCategories = '-*';
-    traceCategories = traceCategories + ',netlog';
+    //traceCategories = traceCategories + ',netlog';
     if (g_instance.timeline)
       traceCategories = traceCategories + ',blink.console,toplevel,disabled-by-default-devtools.timeline,devtools.timeline,disabled-by-default-devtools.timeline.frame,devtools.timeline.frame';
     if (g_instance.timelineStackDepth > 0)

--- a/agent/browser/chrome/extension/release/wpt/script.js
+++ b/agent/browser/chrome/extension/release/wpt/script.js
@@ -121,9 +121,7 @@ wpt.contentScript.collectStats_ = function(customMetrics) {
   var timingRequest = { 'message': 'wptWindowTiming' };
   function addTime(name) {
     if (window.performance.timing[name] > 0) {
-      timingRequest[name] = Math.max(0, (
-        window.performance.timing[name] -
-        window.performance.timing['navigationStart']));
+      timingRequest[name] = window.performance.timing[name];
     }
   };
   addTime('domContentLoadedEventStart');

--- a/agent/browser/chrome/extension/wpt/chromeDebugger.js
+++ b/agent/browser/chrome/extension/wpt/chromeDebugger.js
@@ -129,7 +129,7 @@ wpt.chromeDebugger.StartTrace = function() {
       traceCategories = '*';
     else
       traceCategories = '-*';
-    traceCategories = traceCategories + ',netlog';
+    //traceCategories = traceCategories + ',netlog';
     if (g_instance.timeline)
       traceCategories = traceCategories + ',blink.console,toplevel,disabled-by-default-devtools.timeline,devtools.timeline,disabled-by-default-devtools.timeline.frame,devtools.timeline.frame';
     if (g_instance.timelineStackDepth > 0)

--- a/agent/wptdriver/web_browser.cc
+++ b/agent/wptdriver/web_browser.cc
@@ -163,6 +163,13 @@ bool WebBrowser::RunAndWait() {
           _status.Set(_T("Waiting up to %d seconds for the test to complete"), 
                       (_test._test_timeout / SECONDS_TO_MS));
           DWORD wait_time = _test._test_timeout + 30000;  // Allow for a little extra time for results processing
+
+          // Devtools requests takes more time to process, make sure we are not killing the browser
+          // at the wrong time
+          if (_browser.IsChrome()) {
+            wait_time += 30000;
+          }
+
           #ifdef DEBUG
           wait_time = INFINITE;
           #endif

--- a/agent/wpthook/hook_nspr.cc
+++ b/agent/wpthook/hook_nspr.cc
@@ -149,6 +149,26 @@ void NsprHook::Init() {
   }
 }
 
+void NsprHook::Unregister() {
+  WptTrace(loglevel::kProcess, _T("[wpthook] NsprHook::Unregister()\n"));
+
+  if (_SSL_ImportFD)
+    _hook->removeHook(SSL_ImportFD_Hook);
+
+  if (_PR_Close)
+    _hook->removeHook(PR_Close_Hook);
+
+
+  if (_PR_Write)
+    _hook->removeHook(PR_Close_Hook);
+
+  if (_PR_Read)
+    _hook->removeHook(PR_Read_Hook);
+
+  if (_SSL_SetURL)
+    _hook->removeHook(SSL_SetURL_Hook);
+}
+
 void NsprHook::SetSslFd(PRFileDesc *fd) {
   _sockets.SetSslFd(fd);
 }

--- a/agent/wpthook/hook_nspr.h
+++ b/agent/wpthook/hook_nspr.h
@@ -57,6 +57,7 @@ public:
   NsprHook(TrackSockets& sockets, TestState& test_state, WptTestHook& test);
   ~NsprHook();
   void Init();
+  void Unregister();
 
   void SetSslFd(PRFileDesc *fd);
 

--- a/agent/wpthook/hook_schannel.cc
+++ b/agent/wpthook/hook_schannel.cc
@@ -138,6 +138,19 @@ void SchannelHook::Init() {
         CertVerifyCertificateChainPolicy_Hook);
 }
 
+void SchannelHook::Unregister() {
+  WptTrace(loglevel::kProcess, _T("[wpthook] SchannelHook::Unregister()\n"));
+
+  if (InitializeSecurityContextW_) _hook->removeHook(InitializeSecurityContextW_Hook);
+  if (InitializeSecurityContextA_) _hook->removeHook(InitializeSecurityContextA_Hook);
+  if (DeleteSecurityContext_) _hook->removeHook(DeleteSecurityContext_Hook);
+  if (DecryptMessage_) _hook->removeHook(DecryptMessage_Hook);
+  if (EncryptMessage_) _hook->removeHook(EncryptMessage_Hook);
+
+  if (CertVerifyCertificateChainPolicy_)
+    _hook->removeHook(CertVerifyCertificateChainPolicy_Hook);
+}
+
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
 SECURITY_STATUS SchannelHook::InitializeSecurityContextW(

--- a/agent/wpthook/hook_schannel.h
+++ b/agent/wpthook/hook_schannel.h
@@ -18,6 +18,7 @@ public:
   SchannelHook(TrackSockets& sockets, TestState& test_state, WptTestHook& test);
   ~SchannelHook(void);
   void Init();
+  void Unregister();
 
   SECURITY_STATUS InitializeSecurityContextW(PCredHandle phCredential,
       PCtxtHandle phContext, SEC_WCHAR * pszTargetName, 

--- a/agent/wpthook/hook_wininet.cc
+++ b/agent/wpthook/hook_wininet.cc
@@ -202,6 +202,24 @@ void WinInetHook::Init() {
                   "HttpAddRequestHeadersA", HttpAddRequestHeadersA_Hook);
 }
 
+void WinInetHook::Unregister() {
+  WptTrace(loglevel::kProcess, _T("[wpthook] WinInetHook::Unregister()\n"));
+
+  if (_InternetConnectW) _hook->removeHook(InternetConnectW_Hook);
+  if (_InternetConnectA) _hook->removeHook(InternetConnectA_Hook);
+  if (_HttpOpenRequestA) _hook->removeHook(HttpOpenRequestA_Hook);
+  if (_HttpOpenRequestW) _hook->removeHook(HttpOpenRequestW_Hook);
+  if (_InternetOpenW) _hook->removeHook(InternetOpenW_Hook);
+  if (_InternetOpenA) _hook->removeHook(InternetOpenA_Hook);
+  if (_InternetCloseHandle) _hook->removeHook(InternetCloseHandle_Hook);
+  if (_InternetSetStatusCallback) _hook->removeHook(InternetSetStatusCallback_Hook);
+  if (_HttpSendRequestW) _hook->removeHook(HttpSendRequestW_Hook);
+  if (_HttpSendRequestA) _hook->removeHook(HttpSendRequestA_Hook);
+  if (_FtpOpenFileW) _hook->removeHook(FtpOpenFileW_Hook);
+  if (_FtpOpenFileA) _hook->removeHook(FtpOpenFileA_Hook);
+  if (_HttpAddRequestHeadersW) _hook->removeHook(HttpAddRequestHeadersW_Hook);
+  if (_HttpAddRequestHeadersA) _hook->removeHook(HttpAddRequestHeadersA_Hook);
+}
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
 HINTERNET WinInetHook::InternetOpenW(LPCWSTR lpszAgent, DWORD dwAccessType,

--- a/agent/wpthook/hook_wininet.h
+++ b/agent/wpthook/hook_wininet.h
@@ -49,6 +49,7 @@ public:
   WinInetHook(TrackSockets& sockets, TestState& test_state, WptTest& test);
   ~WinInetHook(void);
   void Init();
+  void Unregister();
 
   HINTERNET	InternetOpenW(LPCWSTR lpszAgent,DWORD dwAccessType,
                       LPCWSTR lpszProxy,LPCWSTR lpszProxyBypass,DWORD dwFlags);

--- a/agent/wpthook/hook_winsock.cc
+++ b/agent/wpthook/hook_winsock.cc
@@ -324,6 +324,35 @@ void CWsHook::Init() {
                                          getaddrinfo_Hook);
 }
 
+void CWsHook::Unregister() {
+  WptTrace(loglevel::kProcess, _T("[wpthook] CWsHook::Unregister()\n"));
+
+  // remove the code hooks
+  if (_WSASocketW) hook.removeHook(WSASocketW_Hook);
+  if (_closesocket) hook.removeHook(closesocket_Hook);
+  if (_connect) hook.removeHook(connect_Hook);
+  if (_recv) hook.removeHook(recv_Hook);
+  if (_send) hook.removeHook(send_Hook);
+  if (_select) hook.removeHook(select_Hook);
+  if (_GetAddrInfoW) hook.removeHook(GetAddrInfoW_Hook);
+  if (_gethostbyname) hook.removeHook(gethostbyname_Hook);
+  if (_GetAddrInfoExA) hook.removeHook(GetAddrInfoExA_Hook);
+  if (_GetAddrInfoExW) hook.removeHook(GetAddrInfoExW_Hook);
+  if (_WSARecv) hook.removeHook(WSARecv_Hook);
+  if (_WSASend) hook.removeHook(WSASend_Hook);
+  if (_WSAGetOverlappedResult) hook.removeHook(WSAGetOverlappedResult_Hook);
+  if (_WSAEventSelect) hook.removeHook(WSAEventSelect_Hook);
+  if (_WSAEnumNetworkEvents) hook.removeHook(WSAEnumNetworkEvents_Hook);
+  if (_CreateThreadpoolIo) hook.removeHook(CreateThreadpoolIo_Hook);
+  if (_CreateThreadpoolIo_base) hook.removeHook(CreateThreadpoolIo_base_Hook);
+  if (_CloseThreadpoolIo) hook.removeHook(CloseThreadpoolIo_Hook);
+  if (_CloseThreadpoolIo_base) hook.removeHook(CloseThreadpoolIo_base_Hook);
+  if (_StartThreadpoolIo) hook.removeHook(StartThreadpoolIo_Hook);
+  if (_StartThreadpoolIo_base) hook.removeHook(StartThreadpoolIo_base_Hook);
+  if (_WSAIoctl) hook.removeHook(WSAIoctl_Hook);
+  if (_getaddrinfo) hook.removeHook(getaddrinfo_Hook);
+}
+
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
 CWsHook::~CWsHook(void) {

--- a/agent/wpthook/hook_winsock.h
+++ b/agent/wpthook/hook_winsock.h
@@ -89,6 +89,7 @@ public:
   CWsHook(TrackDns& dns, TrackSockets& sockets, TestState& test_state);
   virtual ~CWsHook(void);
   void Init();
+  void Unregister();
 
   // straight winsock hooks
   SOCKET	WSASocketW(int af, int type, int protocol, 

--- a/agent/wpthook/wpthook.h
+++ b/agent/wpthook/wpthook.h
@@ -72,6 +72,7 @@ public:
   void SetNewPageLoad();
   bool IsNewPageLoad();
   void Save(bool merge = false);
+  void UnregisterHooks();
   void Cleanup();
   void ShutdownNow();
   void OnWindowTimingReceived();


### PR DESCRIPTION
When a measurment times out and a substential number of requests
are still being issued by the browser, the wpt hook
can become unresponsive while it processes all HTTP requests and
hook callbacks making it miss the deadline of 40s. Passed this timeout,
the WPT driver kills the browser and all results are lost.

This PR unregister the wpt hook from all windows hook and try to lesser
the load of netlog calls.
