### PR TITLE
Remove Chrome 'process-per-tab' option.

### DIFF
--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -48,7 +48,6 @@ static const TCHAR * CHROME_REQUIRED_OPTIONS[] = {
   _T("disable-background-networking"),
   _T("no-default-browser-check"),
   _T("no-first-run"),
-  _T("process-per-tab"),
   _T("new-window"),
   _T("disable-translate"),
   _T("disable-desktop-notifications"),


### PR DESCRIPTION
This option causes, in combination with the hook, causes some websites
to fail in unexpected ways.
