### PR TITLE
Exposes screenshots into the HAR

### DIFF
--- a/agent/wptdriver/web_driver.h
+++ b/agent/wptdriver/web_driver.h
@@ -12,6 +12,8 @@ public:
   void Terminate();
 
 private:
+  bool RunImageHash();
+  bool RunVisuallyComplete();
   bool SpawnWebDriverServer();
   bool SpawnWebDriverClient();
   void TerminateWebDriverServer();

--- a/agent/wptdriver/wpt_driver_core.h
+++ b/agent/wptdriver/wpt_driver_core.h
@@ -60,6 +60,8 @@ private:
   bool WebDriverTest(WptTestDriver& test, WebBrowser &browser);
   bool BrowserTest(WptTestDriver& test, WebBrowser &browser);
   bool SetupWebPageReplay(WptTestDriver& test, WebBrowser &browser);
+  bool RunImageHash(WptTestDriver& test);
+  bool RunVisuallyComplete(WptTestDriver& test);
   void Init(void);
   void Cleanup(void);
   void FlushDNS(void);

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -172,6 +172,12 @@ bool WptSettings::Load(void) {
     _webdriver_supported = true;
   }
 
+  if (GetPrivateProfileString(
+    _T("WebPageTest"), _T("ImageTools"), _T(""), buff, _countof(buff), iniFile)) {
+    _imagetools_command = buff;
+    _imagetools_command.Trim(_T("\""));
+  }
+
   if (_webdriver_supported) {
     if (GetPrivateProfileString(
       _T("WebPageTest"), _T("WebDriverServer"), _T(""), buff, _countof(buff), iniFile)) {

--- a/agent/wptdriver/wpt_settings.h
+++ b/agent/wptdriver/wpt_settings.h
@@ -133,5 +133,6 @@ public:
   CString _webdriver_server_command;
   CString _webdriver_client_command;
   CString _webdriver_server_url;
+  CString _imagetools_command;
   bool _webdriver_supported;
 };

--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -65,8 +65,8 @@ WptTest::WptTest(void):
 
   // figure out what our working diriectory is
   TCHAR path[MAX_PATH];
-  if( SUCCEEDED(SHGetFolderPath(NULL, CSIDL_APPDATA | CSIDL_FLAG_CREATE,
-                                NULL, SHGFP_TYPE_CURRENT, path)) ) {
+  if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_APPDATA | CSIDL_FLAG_CREATE,
+    NULL, SHGFP_TYPE_CURRENT, path))) {
     PathAppend(path, _T("webpagetest"));
     CreateDirectory(path, NULL);
     _directory = path;
@@ -74,6 +74,13 @@ WptTest::WptTest(void):
     lstrcat(path, _T("_data"));
     CreateDirectory(path, NULL);
     _test_file = CString(path) + _T("\\test.dat");
+
+    _screenshots_dir.Format(_T("%s\\screenshots\\"), _directory);
+    CreateDirectory(_screenshots_dir, NULL);
+
+    _progress_dir.Format(_T("%s\\progress\\"), _directory);
+    //_progress_dir = _T("C:\\Users\\Public\\webpagetest\\Debug\\screenshots\\");
+    CreateDirectory(_progress_dir, NULL);
   }
   InitializeCriticalSection(&cs_);
   _tcp_port_override.InitHashTable(257);

--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -79,7 +79,6 @@ WptTest::WptTest(void):
     CreateDirectory(_screenshots_dir, NULL);
 
     _progress_dir.Format(_T("%s\\progress\\"), _directory);
-    //_progress_dir = _T("C:\\Users\\Public\\webpagetest\\Debug\\screenshots\\");
     CreateDirectory(_progress_dir, NULL);
   }
   InitializeCriticalSection(&cs_);

--- a/agent/wptdriver/wpt_test.h
+++ b/agent/wptdriver/wpt_test.h
@@ -146,6 +146,8 @@ public:
   CString _id;
   CString _file_base;
   CString _directory;
+  CString _screenshots_dir;
+  CString _progress_dir;
   CString _url;
   int     _runs;
   int     _discard;

--- a/agent/wpthook/screen_capture.h
+++ b/agent/wpthook/screen_capture.h
@@ -38,6 +38,7 @@ public:
     DOCUMENT_COMPLETE,
     FULLY_LOADED,
     RESPONSIVE_CHECK,
+    RESULT,
     UNKNOWN
   } TYPE;
 

--- a/agent/wpthook/test_state.cc
+++ b/agent/wpthook/test_state.cc
@@ -398,7 +398,7 @@ void TestState::Done(bool force) {
   WptTrace(loglevel::kFunction, _T("[wpthook] - **** TestState::Done()\n"));
   if (_active) {
     GetCPUTime(_end_cpu_time, _end_total_time);
-    _screen_capture.Capture(_frame_window, CapturedImage::FULLY_LOADED);
+    
 
     if (force || !_test._combine_steps) {
       // kill the timer that was collecting periodic data (cpu, video, etc)
@@ -429,6 +429,13 @@ BOOL CALLBACK MakeTopmost(HWND hwnd, LPARAM lParam) {
     }
   }
   return TRUE;
+}
+
+/*-----------------------------------------------------------------------------
+Capture session result image
+-----------------------------------------------------------------------------*/
+void TestState::GrabResultScreenshot() {
+  _screen_capture.Capture(_frame_window, CapturedImage::RESULT);
 }
 
 /*-----------------------------------------------------------------------------

--- a/agent/wpthook/test_state.h
+++ b/agent/wpthook/test_state.h
@@ -100,6 +100,7 @@ public:
   void Done(bool force = false);
   bool IsDone();
   void GrabVideoFrame(bool force = false);
+  void GrabResultScreenshot();
   void CollectData();
   void Reset(bool cascade = true);
   void Init();

--- a/agent/wpthook/wpthook.cc
+++ b/agent/wpthook/wpthook.cc
@@ -227,6 +227,9 @@ void WptHook::OnReport() {
 
   KillTimer(message_window_, TIMER_FORCE_REPORT);
   if (!reported_) {
+    // Grab session result screenshot in case this is the end of the measurement
+    test_state_.GrabResultScreenshot();
+
     reported_ = true;
     if (test_._combine_steps) {
       results_.Save();
@@ -255,6 +258,10 @@ void WptHook::Report() {
 }
 
 void WptHook::Save(bool merge) {
+  // Grab session result screenshot in case this is the end of the measurement
+  test_state_.GrabResultScreenshot();
+  WptTrace(loglevel::kProcess, _T("[wpthook] WptHook::Save()\n"));
+
   if (!reported_) {
     reported_ = true;
     results_.Save(merge);


### PR DESCRIPTION
This PR exposes exposes 3 types of screenshots:
1. Session results: the very last screen for a given measurement. Saved
   in har.log._resultScreenshot
2. Each page visually complete in har.log.pages.[].screenshots.[]
3. Screenshots taken by the script with selenium API. If the screenshot
   is saved to a file, the filename (without its extension) becomes the
   screenshot label.

In addition to the image path, the image sha1 and timestamp are saved in
the same image object. The sha1 is computed directly by the agent when
the image is saved.

This PR also removes some images not used by AppDynamics synthetic
service.
