### PR TITLE
Don't include visually complete when page number mismatch

### DIFF
--- a/www/har.inc.php
+++ b/www/har.inc.php
@@ -442,6 +442,7 @@ function AddImages($id, $testPath, &$result) {
                 // This is probably a Chrome devtools vs WPT hook page
                 // detection problem. When this happens, ignore all visually complete
                 // images.
+                logAlways("Page discrepency in visually complete screenshot. HAR has " . $pagesCount . " and Visually complete image filename has " . ($page + 1));
                 $includeVC = false;
                 continue;
             }


### PR DESCRIPTION
When doing measurement with Chrome, it is possible that the page number
included in the visually complete image filename exceeds the number of
pages in the HAR due to the page separation bug we have. This PR ignores
all visually complete images if the number of pages are not the same
between devtools and visually complete filename.
