### PR TITLE
Fix utf8 related har generation error

### DIFF
--- a/www/har.inc.php
+++ b/www/har.inc.php
@@ -50,14 +50,14 @@ function GenerateHAR($id, $testPath, $options) {
       $pretty_print = true;
     if (isset($options['php']) && $options['php']) {
       if ($pretty_print && $json_encode_good)
-        $json = json_encode($harData, JSON_PRETTY_PRINT);
+        $json = json_encode($harData, JSON_PRETTY_PRINT | JSON_PARTIAL_OUTPUT_ON_ERROR);
       else
-        $json = json_encode($harData);
+        $json = json_encode($harData | JSON_PARTIAL_OUTPUT_ON_ERROR);
     } elseif ($json_encode_good) {
       if ($pretty_print)
-        $json = json_encode($harData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        $json = json_encode($harData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_PARTIAL_OUTPUT_ON_ERROR);
       else
-        $json = json_encode($harData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $json = json_encode($harData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR);
     } else {    
       $jsonLib = new Services_JSON();
       $json = $jsonLib->encode($harData);


### PR DESCRIPTION
The har was sometimes not generated correctly due to errors in serializing
strings which are not properly converted to utf8. This patch lets the json
encoder deal with these errors.
