### PR TITLE
Reduce time needed to save a measurement

### DIFF
--- a/agent/wpthook/mongoose/mongoose.c
+++ b/agent/wpthook/mongoose/mongoose.c
@@ -1074,6 +1074,10 @@ static int start_thread(struct mg_context *ctx, mg_thread_func_t func,
 
   hThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) func, param, 0,
                          NULL);
+
+  // boost priority
+  SetThreadPriority(hThread, THREAD_PRIORITY_ABOVE_NORMAL);
+
   if (hThread != NULL) {
     (void) CloseHandle(hThread);
   }


### PR DESCRIPTION
When a page uses nearly 100% CPU, saving results is challenging. To maximize the chance to save data the following steps have been taken:
1. the priorityof mongoose thread have been increase. Mongoose threads are the one actually saving the data on disk.
2. The BHO has also been optimize to stop looking for page stats when the page has been loaded and page stats collected.
3. Saving images happens last, after all resources have been saved
4. Saving images is now time bound. The hook has 10s
   to save all images for a given step. On a normal CPU usage
   this represents ~ 100 different images.
