### PR TITLE
Use an optimize write strategy for log

### DIFF
--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -103,6 +103,9 @@ WebPagetest::~WebPagetest(void) {
 bool WebPagetest::GetTest(WptTestDriver& test) {
   bool ret = false;
 
+  // Rotate global logs if needed
+  _settings.RotateGlobalLogs();
+
   // Test if lock screen is active. If lockscreen is active, wnd will be NULL
   HWND wnd = GetForegroundWindow();
   if (wnd == NULL) {

--- a/agent/wptdriver/wpt_driver_core.cc
+++ b/agent/wptdriver/wpt_driver_core.cc
@@ -288,9 +288,9 @@ bool WptDriverCore::BrowserTest(WptTestDriver& test, WebBrowser &browser) {
   test.SetFileBase();
 
   // activate logs
-  logfile_handle = CreateFile(test._file_base + _T("_wptdriver.log"), GENERIC_WRITE,
+  logfile_handle = CreateFile(test._file_base + _T("_wptdriver.log"), FILE_APPEND_DATA,
     FILE_SHARE_READ | FILE_SHARE_WRITE,
-    NULL, OPEN_ALWAYS, 0, 0);
+    NULL, OPEN_ALWAYS, FILE_FLAG_WRITE_THROUGH, 0);
   if (logfile_handle == INVALID_HANDLE_VALUE) {
     WptTrace(loglevel::kFunction, _T("Failed to open log file. Error: %d"), GetLastError());
   } else {

--- a/agent/wptdriver/wpt_settings.h
+++ b/agent/wptdriver/wpt_settings.h
@@ -109,12 +109,14 @@ public:
   bool GetUrlText(CString url, CString &response, LPCTSTR headers = NULL);
   bool UpdateSoftware();
   bool ReInstallBrowser();
+  void RotateGlobalLogs();
 
   CString _server;
   CString _username;
   CString _password;
   CString _location;
   CString _key;
+  CString _logFile;
   DWORD   _timeout;
   DWORD   _startup_delay;
   DWORD   _polling_delay;

--- a/agent/wpthook/wpthook.cc
+++ b/agent/wpthook/wpthook.cc
@@ -103,8 +103,8 @@ WptHook::WptHook(void):
       free( pVersion );
     }
   }
-  logfile_handle = CreateFile(file_base_ + WPTHOOK_LOG, GENERIC_WRITE, 0,
-    NULL, OPEN_ALWAYS, 0, 0);
+  logfile_handle = CreateFile(file_base_ + WPTHOOK_LOG, FILE_APPEND_DATA, 0,
+    NULL, OPEN_ALWAYS, FILE_FLAG_WRITE_THROUGH, 0);
   if (logfile_handle == INVALID_HANDLE_VALUE) {
     WptTrace(loglevel::kFunction, _T("[wpthook] Failed to open log file. Error: %d"), GetLastError());
   } else {


### PR DESCRIPTION
Use FILE_APPEND_DATA with the FILE_FLAG_WRITE_THROUGH to open
log files.
FILE_APPEND_DATA guaranties non-overlapping writes and FILE_FLAG_WRITE_THROUGH
is equivalent of doing a write followed by a flush, but is more
efficient.
