### PR TITLE
Buffer all logs to improve performance

### DIFF
--- a/agent/wptdriver/util.h
+++ b/agent/wptdriver/util.h
@@ -38,8 +38,6 @@ enum {
 extern const DWORD CAPABILITIES[::nCapabilities];
 extern HANDLE logfile_handle;
 extern HANDLE global_logfile_handle;
-extern CRITICAL_SECTION *logfile_cs;
-extern CRITICAL_SECTION *global_logfile_cs;
 
 namespace loglevel {
   const int kError = 1;
@@ -65,6 +63,7 @@ DWORD ElapsedMs(LARGE_INTEGER start, LARGE_INTEGER end);
 CStringA UTF16toUTF8(const CStringW& utf16);
 void WriteToLogFile(CStringA &msg);
 void WptTrace(int level, LPCTSTR format, ...);
+void WptTraceFlush();
 
 typedef CAtlList<CStringA> HookSymbolNames;
 typedef CAtlMap<CStringA, DWORD64> HookOffsets;

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -103,6 +103,9 @@ WebPagetest::~WebPagetest(void) {
 bool WebPagetest::GetTest(WptTestDriver& test) {
   bool ret = false;
 
+  // flush previous logs
+  WptTraceFlush();
+
   // Rotate global logs if needed
   _settings.RotateGlobalLogs();
 

--- a/agent/wptdriver/wpt_driver_core.cc
+++ b/agent/wptdriver/wpt_driver_core.cc
@@ -288,18 +288,6 @@ bool WptDriverCore::BrowserTest(WptTestDriver& test, WebBrowser &browser) {
 
   test.SetFileBase();
 
-  // activate logs
-  logfile_handle = CreateFile(test._file_base + _T("_wptdriver.log"), FILE_APPEND_DATA,
-    FILE_SHARE_READ | FILE_SHARE_WRITE,
-    NULL, OPEN_ALWAYS, FILE_FLAG_WRITE_THROUGH, 0);
-  if (logfile_handle == INVALID_HANDLE_VALUE) {
-    WptTrace(loglevel::kFunction, _T("Failed to open log file. Error: %d"), GetLastError());
-  } else {
-    logfile_cs = (CRITICAL_SECTION *)malloc(sizeof(CRITICAL_SECTION));
-    ZeroMemory(logfile_cs, sizeof(CRITICAL_SECTION));
-    InitializeCriticalSection(logfile_cs);
-  }
-
   WptTrace(loglevel::kFunction, _T("[wptdriver] WptDriverCore::BrowserTest\n"));
 
   test._run_error.Empty();
@@ -351,12 +339,18 @@ bool WptDriverCore::BrowserTest(WptTestDriver& test, WebBrowser &browser) {
   WptTrace(loglevel::kFunction, 
             _T("[wptdriver] WptDriverCore::BrowserTest done\n"));
 
+  // activate logs
+  logfile_handle = CreateFile(test._file_base + _T("_wptdriver.log"), FILE_APPEND_DATA,
+    FILE_SHARE_READ | FILE_SHARE_WRITE,
+    NULL, OPEN_ALWAYS, FILE_FLAG_WRITE_THROUGH, 0);
+  if (logfile_handle == INVALID_HANDLE_VALUE) {
+    WptTrace(loglevel::kFunction, _T("Failed to open log file. Error: %d"), GetLastError());
+  }
+
+  WptTraceFlush();
   // close log file handles
   if (logfile_handle != INVALID_HANDLE_VALUE) {
     CloseHandle(logfile_handle);
-    DeleteCriticalSection(logfile_cs);
-    free(logfile_cs);
-    logfile_cs = NULL;
     logfile_handle = NULL;
   }
 

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -133,11 +133,6 @@ bool WptSettings::Load(void) {
   if (logfile_handle == INVALID_HANDLE_VALUE) {
     WptTrace(loglevel::kFunction, _T("Failed to open log file. Error: %d"), GetLastError());
   }
-  else {
-    global_logfile_cs = (CRITICAL_SECTION *)malloc(sizeof(CRITICAL_SECTION));
-    ZeroMemory(global_logfile_cs, sizeof(CRITICAL_SECTION));
-    InitializeCriticalSection(global_logfile_cs);
-  }
 
   if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_APPDATA | CSIDL_FLAG_CREATE,
                                 NULL, SHGFP_TYPE_CURRENT, buff))) {

--- a/agent/wptdriver/wptdriver.cc
+++ b/agent/wptdriver/wptdriver.cc
@@ -49,8 +49,6 @@ INT_PTR CALLBACK	About(HWND, UINT, WPARAM, LPARAM);
 
 HANDLE logfile_handle = NULL;
 HANDLE global_logfile_handle = NULL;
-CRITICAL_SECTION *logfile_cs = NULL;
-CRITICAL_SECTION *global_logfile_cs = NULL;
 
 int APIENTRY _tWinMain(HINSTANCE hInstance,
                      HINSTANCE hPrevInstance,

--- a/agent/wpthook/dllmain.cc
+++ b/agent/wpthook/dllmain.cc
@@ -95,6 +95,9 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:
     case DLL_PROCESS_DETACH:
+      if (global_hook) {
+        global_hook->FlushLogs();
+      }
       break;
   }
   return ok;

--- a/agent/wpthook/wpthook.cc
+++ b/agent/wpthook/wpthook.cc
@@ -36,9 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 WptHook * global_hook = NULL;
 HANDLE logfile_handle = NULL;
-CRITICAL_SECTION *logfile_cs = NULL;
 HANDLE global_logfile_handle = NULL;
-CRITICAL_SECTION *global_logfile_cs = NULL;
 
 extern HINSTANCE global_dll_handle;
 
@@ -102,15 +100,6 @@ WptHook::WptHook(void):
       }
       free( pVersion );
     }
-  }
-  logfile_handle = CreateFile(file_base_ + WPTHOOK_LOG, FILE_APPEND_DATA, 0,
-    NULL, OPEN_ALWAYS, FILE_FLAG_WRITE_THROUGH, 0);
-  if (logfile_handle == INVALID_HANDLE_VALUE) {
-    WptTrace(loglevel::kFunction, _T("[wpthook] Failed to open log file. Error: %d"), GetLastError());
-  } else {
-    logfile_cs = (CRITICAL_SECTION *)malloc(sizeof(CRITICAL_SECTION));
-    ZeroMemory(logfile_cs, sizeof(CRITICAL_SECTION));
-    InitializeCriticalSection(logfile_cs);
   }
 }
 
@@ -296,6 +285,17 @@ void WptHook::ShutdownNow() {
     ::SendMessage(test_state_._frame_window, WM_CLOSE, 0, 0);
   }
   WptTrace(loglevel::kTrace, _T("[wpthook] Leaving ShutdownNow()"));
+}
+
+void WptHook::FlushLogs() {
+  logfile_handle = CreateFile(file_base_ + WPTHOOK_LOG, FILE_APPEND_DATA, 0,
+    NULL, OPEN_ALWAYS, FILE_FLAG_WRITE_THROUGH, 0);
+  if (logfile_handle == INVALID_HANDLE_VALUE) {
+    WptTrace(loglevel::kFunction, _T("[wpthook] Failed to open log file. Error: %d"), GetLastError());
+  } else {
+    WptTraceFlush();
+    CloseHandle(logfile_handle);
+  }
 }
 
 

--- a/agent/wpthook/wpthook.h
+++ b/agent/wpthook/wpthook.h
@@ -77,6 +77,7 @@ public:
   void ShutdownNow();
   void OnWindowTimingReceived();
   bool IsWindowTimingReceived();
+  void FlushLogs();
 
 private:
   CWsHook   winsock_hook_;


### PR DESCRIPTION
This PR delay logs writes to improve performance. WPT driver logs are flushed on GetWork. Hooks logs are flushed on hook termination.

Test:
- Tested on all browser to verify logs are save (hook + driver)
- Tested on scripted measurements to verify logs are saved
