### PR TITLE
Add external screenshot support

### DIFF
--- a/agent/wptdriver/util.cc
+++ b/agent/wptdriver/util.cc
@@ -638,6 +638,25 @@ bool  RegexMatch(CStringA str, CStringA regex) {
   return matched;
 }
 
+bool  RegexSearch(CStringA str, CStringA regex) {
+  bool matched = false;
+
+  if (str.GetLength()) {
+    if (!regex.GetLength() ||
+        !regex.Compare("*") ||
+        !str.CompareNoCase(regex)) {
+      matched = true;
+    } else if (regex.GetLength()) {
+        std::tr1::regex match_regex(regex,
+                std::tr1::regex_constants::icase |
+                std::tr1::regex_constants::ECMAScript);
+        matched = std::tr1::regex_search((LPCSTR)str, match_regex);
+    }
+  }
+
+  return matched;
+}
+
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
 CStringA JSONEscapeA(CStringA src) {

--- a/agent/wptdriver/util.h
+++ b/agent/wptdriver/util.h
@@ -85,6 +85,7 @@ DWORD   HttpSaveFile(CString url, CString file);
 CString HashFileMD5(CString file);
 bool FileExists(CString file);
 bool  RegexMatch(CStringA str, CStringA regex);
+bool  RegexSearch(CStringA str, CStringA regex);
 CStringA JSONEscape(CString src);
 CStringA JSONEscapeA(CStringA src);
 void QueryPerfCounter(__int64 &counter);

--- a/agent/wptdriver/web_driver.cc
+++ b/agent/wptdriver/web_driver.cc
@@ -241,9 +241,19 @@ bool WebDriver::SpawnWebDriverClient() {
   // Add the test id
   options.Add(_T("--id"));
   options.Add(_test._id);
+
+  if (_test._useImageToolsScreenshots) {
+    // set imagetools options
+    options.Add(_T("--imagetools"));
+    options.Add(_settings._imagetools_command);
+    options.Add(_T("--screenshots-path"));
+    options.Add(_test._progress_dir);
+  }
+
   // Add the browser we are about to launch.
   options.Add(_T("--browser"));
   options.Add(_T("\"") + browser + _T("\""));
+
   if (!_test._script.GetLength()) {
     // Script is empty. Test the said url.
     options.Add(_T("--test-url"));
@@ -271,6 +281,8 @@ bool WebDriver::SpawnWebDriverClient() {
   // pass the test directory to the client to record stdout/stderr and other result files
   options.Add(_T("--outputDir"));
   options.Add(_T("\"") + _test._directory + _T("\""));
+
+
   // pass the test timeout to the client
   if (_test._test_timeout > 0) {
     CString timeout;
@@ -279,6 +291,7 @@ bool WebDriver::SpawnWebDriverClient() {
     options.Add(_T("--timeout"));
     options.Add(timeout);
   }
+
   ConstructCmdLine(_settings._webdriver_client_command, options, CString(""), cmdLine);
 
   ZeroMemory(&si, sizeof(STARTUPINFO));

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -296,8 +296,6 @@ bool WebPagetest::UploadIncrementalResults(WptTestDriver& test) {
       ret = UploadData(test, false);
       SetCPUUtilization(0);
     }
-  } else {
-    DeleteIncrementalResults(test);
   }
 
   return ret;
@@ -366,8 +364,6 @@ bool WebPagetest::UploadImages(WptTestDriver& test,
     CString file = image_files.GetNext(pos);
     if (!test._discard_test)
       ret = UploadFile(url, false, test, file);
-    if (ret)
-      DeleteFile(file);
   }
   return ret;
 }
@@ -386,8 +382,6 @@ bool WebPagetest::UploadData(WptTestDriver& test, bool done) {
   if (ret || done) {
     CString url = _settings._server + _T("work/workdone.php");
     ret = UploadFile(url, done, test, file);
-    if (ret)
-      DeleteFile(file);
   }
 
   return ret;
@@ -680,9 +674,6 @@ bool WebPagetest::UploadFile(CString url, bool done, WptTestDriver& test,
   if (file_handle != INVALID_HANDLE_VALUE)
     CloseHandle( file_handle );
 
-  if (ret)
-    DeleteFile(file);
-
   AtlTrace(_T("[wptdriver] - Upload %s"), ret ? _T("SUCCEEDED") : _T("FAILED"));
 
   return ret;
@@ -903,7 +894,6 @@ bool WebPagetest::CompressResults(CString directory, CString zip_file) {
               
               CloseHandle(new_file);
             }
-            DeleteFile(file_path);
           }
         }
       } while (FindNextFile(find_handle, &fd));

--- a/agent/wptdriver/wpt_driver_core.cc
+++ b/agent/wptdriver/wpt_driver_core.cc
@@ -373,7 +373,11 @@ bool WptDriverCore::RunImageHash(WptTestDriver& test) {
   _settings._imagetools_command.Replace(_T("%RESULTDIR%"), test._directory);
 
   CString cmd;
-  cmd.Format(_T("%s imagehash -s %s -d %s -j -q %0.2f"), _settings._imagetools_command, test._screenshots_dir, test._directory, (float)test._image_quality / 100.0f);
+  if (test._useImageToolsScreenshots) {
+    cmd.Format(_T("%s imagehash -s %s -d %s -j -x -q %0.2f"), _settings._imagetools_command, test._directory, test._directory, (float)test._image_quality / 100.0f);
+  } else {
+    cmd.Format(_T("%s imagehash -s %s -d %s -j -q %0.2f"), _settings._imagetools_command, test._screenshots_dir, test._directory, (float)test._image_quality / 100.0f);
+  }
   _status.Set(_T("Launching: %s"), cmd);
   if (!CreateProcess(NULL, cmd.GetBuffer(), NULL, NULL, TRUE, 0, NULL,
     NULL, &si, &it_info)) {
@@ -408,7 +412,12 @@ bool WptDriverCore::RunVisuallyComplete(WptTestDriver& test) {
   _settings._imagetools_command.Replace(_T("%RESULTDIR%"), test._directory);
 
   CString cmd;
-  cmd.Format(_T("%s visuallycomplete -s %s -d %s"), _settings._imagetools_command, test._progress_dir, test._screenshots_dir);
+
+  if (test._useImageToolsScreenshots) {
+    cmd.Format(_T("%s visuallycomplete -l -s %s -d %s --steps-timing %s"), _settings._imagetools_command, test._progress_dir, test._directory, test._file_base + _T("_steps_timing.txt"));
+  } else {
+    cmd.Format(_T("%s visuallycomplete -s %s -d %s"), _settings._imagetools_command, test._progress_dir, test._screenshots_dir);
+  }
   _status.Set(_T("Launching: %s"), cmd);
   if (!CreateProcess(NULL, cmd.GetBuffer(), NULL, NULL, TRUE, 0, NULL,
     NULL, &si, &it_info)) {

--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -110,6 +110,7 @@ void WptTest::Reset(void) {
   _trace = false;
   _netlog = false;
   _video = false;
+  _useImageToolsScreenshots = false;
   _spdy3 = false;
   _noscript = false;
   _clear_certs = false;
@@ -321,6 +322,7 @@ bool WptTest::Load(CString& test) {
     } else if (!reading_headers && !line.Trim().CompareNoCase(_T("[Script]"))) {
       // grab the rest of the response as the script
       _script = test.Mid(linePos).Trim();
+
       done = true;
     } 
 
@@ -338,8 +340,14 @@ bool WptTest::Load(CString& test) {
     _discard = 0;
   }
 
-  if (_script.GetLength())
+  if (_script.GetLength()) {
     _test_timeout *= _script_timeout_multiplier;
+
+    // check if we use imagetools for script capture. This information is passed as an in-script metadata
+    _useImageToolsScreenshots = RegexSearch((LPCSTR)CT2A(_script), CStringA(_T("useImageToolsScreenshots\\s*:\\s*true")));
+    WptTrace(loglevel::kFunction, _T("WptTest::Load() - use imagetools screenshots %d"), _useImageToolsScreenshots);
+  }
+
   WptTrace(loglevel::kFunction, _T("WptTest::Load() - Loaded test %s\n"), 
                                                                 (LPCTSTR)_id);
 

--- a/agent/wptdriver/wpt_test.h
+++ b/agent/wptdriver/wpt_test.h
@@ -159,6 +159,7 @@ public:
   int     _timelineStackDepth;
   bool    _trace;
   bool    _netlog;
+  bool    _useImageToolsScreenshots;
   bool    _video;
   bool    _spdy3;
   bool    _noscript;

--- a/agent/wpthook/test_state.cc
+++ b/agent/wpthook/test_state.cc
@@ -306,8 +306,9 @@ void TestState::OnLoad() {
     QueryPerformanceCounter(&_on_load);
     GetCPUTime(_doc_cpu_time, _doc_total_time);
     ActivityDetected();
-    _screen_capture.Capture(_frame_window,
-                            CapturedImage::DOCUMENT_COMPLETE);
+    if (!_test._useImageToolsScreenshots) {
+      _screen_capture.Capture(_frame_window, CapturedImage::DOCUMENT_COMPLETE);
+    }
     _current_document = 0;
   }
 }
@@ -435,7 +436,9 @@ BOOL CALLBACK MakeTopmost(HWND hwnd, LPARAM lParam) {
 Capture session result image
 -----------------------------------------------------------------------------*/
 void TestState::GrabResultScreenshot() {
-  _screen_capture.Capture(_frame_window, CapturedImage::RESULT);
+  if (!_test._useImageToolsScreenshots) {
+    _screen_capture.Capture(_frame_window, CapturedImage::RESULT);
+  }
 }
 
 /*-----------------------------------------------------------------------------
@@ -494,7 +497,7 @@ void TestState::UpdateBrowserWindow() {
     Grab a video frame if it is appropriate
 -----------------------------------------------------------------------------*/
 void TestState::GrabVideoFrame(bool force) {
-  if (_active && _frame_window && (force || received_data_)) {
+  if (!_test._useImageToolsScreenshots && _active && _frame_window && (force || received_data_)) {
     // use a falloff on the resolution with which we capture video
     bool grab_video = false;
     LARGE_INTEGER now;
@@ -932,7 +935,7 @@ void TestState::ResizeBrowserForResponsiveTest() {
   browser-specific extensions
 -----------------------------------------------------------------------------*/
 void TestState::CheckResponsive() {
-  if (_frame_window) {
+  if (!_test._useImageToolsScreenshots && _frame_window) {
     _screen_capture.Capture(_frame_window, CapturedImage::RESPONSIVE_CHECK,
                             false);
   }


### PR DESCRIPTION
This PR add support for external screenshots (provided by the imagetools).
To activate the external screenshots, a script should have thefollowing header:

```
'''yml
WptDriver:
  useImageToolsScreenshots: true
'''
```

Tested with and without the flag and multistep scripts.
