### PR TITLE
Reduce time to reboot when blackscreen detected

### DIFF
--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -44,7 +44,7 @@ using namespace Gdiplus;
 
 static const TCHAR * NO_FILE = _T("");
 static const short MAX_REBOOT = 3;
-static const short MAX_LOCKSCREEN_WAIT = 60 * 10; // reboot after 10min of lock screen
+static const short MAX_LOCKSCREEN_WAIT = 60 * 5; // reboot after 5min of lock screen
 
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/


### PR DESCRIPTION
This patch reduces the time before an agent will automatically reboot from 10 minutes to 5 minutes.
