### PR TITLE
CORE-76880 Disable popup blocking to enable scripting popups

### DIFF
--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -58,6 +58,7 @@ static const TCHAR * CHROME_REQUIRED_OPTIONS[] = {
   _T("disable-component-update"),
   _T("disable-background-downloads"),
   _T("ignore-certificate-errors"),
+  _T("disable-popup-blocking"),
   _T("test-type"),
   _T("allow-running-insecure-content"),
   _T("silent-debugger-extension-api"),


### PR DESCRIPTION
Chrome will now accept popup by default. This PR has been tested
with a site that opens a popup.
