### PR TITLE
CORE-76921 Save last image as session result

### DIFF
--- a/agent/wpthook/results.cc
+++ b/agent/wpthook/results.cc
@@ -137,7 +137,9 @@ void Results::Save(bool merge) {
   DWORD priority = GetThreadPriority(GetCurrentThread());
   SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
   WptTrace(loglevel::kFunction, _T("[wpthook] - Results::Save()\n"));
+
   if (!_saved) {
+    SaveResultImage();
     ProcessRequests(merge);
     if (_test._log_data) {
       if (!merge) {
@@ -230,7 +232,7 @@ void Results::SaveStatusMessages(void) {
 
 /*-----------------------------------------------------------------------------
 -----------------------------------------------------------------------------*/
-void Results::SaveImages(void) {
+void Results::SaveResultImage(void) {
   // save the event-based images
   CxImage image; 
 
@@ -240,7 +242,9 @@ void Results::SaveImages(void) {
 
     SaveImage(image, _test._screenshots_dir + IMAGE_RESULT_PNG, _test._image_quality, false, _test._full_size_video);
   }
+}
 
+void Results::SaveImages(void) {
   SaveVideo();
 }
 

--- a/agent/wpthook/results.h
+++ b/agent/wpthook/results.h
@@ -100,6 +100,7 @@ private:
   void SaveRequests(bool merge);
   void SaveRequest(HANDLE file, HANDLE headers, Request * request, int index);
   void SaveImages(void);
+  void SaveResultImage(void);
   void SaveVideo(void);
   void SaveProgressData(void);
   void SaveStatusMessages(void);

--- a/agent/wpthook/screen_capture.cc
+++ b/agent/wpthook/screen_capture.cc
@@ -102,11 +102,13 @@ bool ScreenCapture::GetImage(CapturedImage::TYPE type, CxImage& image) {
   bool ret = false;
   image.Destroy();
   EnterCriticalSection(&cs);
-  POSITION pos = _captured_images.GetHeadPosition();
+  POSITION pos = _captured_images.GetTailPosition();
   while (pos) {
-    CapturedImage& captured_image = _captured_images.GetNext(pos);
-    if (captured_image._type == type)
+    CapturedImage& captured_image = _captured_images.GetPrev(pos);
+    if (captured_image._type == type) {
       ret = captured_image.Get(image);
+      break;
+    }
   }
   LeaveCriticalSection(&cs);
 


### PR DESCRIPTION
This PR fixes a bug were incremental saves is not saving a new
result image.

Test:
- Run scripted measurement on google that does a search a verify the
  result image contains the result of the search
- Run URL measurement
