### PR TITLE
Flexible config parameters

### DIFF
--- a/agent/wptdriver/web_driver.cc
+++ b/agent/wptdriver/web_driver.cc
@@ -254,6 +254,10 @@ bool WebDriver::SpawnWebDriverClient() {
   options.Add(_T("--browser"));
   options.Add(_T("\"") + browser + _T("\""));
 
+  if (_test._noLockstep) {
+    options.Add(_T("--no-lockstep"));
+  }
+
   if (!_test._script.GetLength()) {
     // Script is empty. Test the said url.
     options.Add(_T("--test-url"));

--- a/agent/wptdriver/webpagetest.cc
+++ b/agent/wptdriver/webpagetest.cc
@@ -161,7 +161,12 @@ bool WebPagetest::GetTest(WptTestDriver& test) {
   _lockScreen = 0;
 
 
-  DeleteDirectory(test._directory, false);
+  if (_settings._dontCleanupResults) {
+    WptTrace(loglevel::kError, _T("[wptdriver] - Results directory not deleted and left behind"));
+  }
+  else {
+    DeleteDirectory(test._directory, false);
+  }
 
 
   // build the url for the request

--- a/agent/wptdriver/wpt_driver_core.cc
+++ b/agent/wptdriver/wpt_driver_core.cc
@@ -338,8 +338,10 @@ bool WptDriverCore::BrowserTest(WptTestDriver& test, WebBrowser &browser) {
   }
 
   // process images
-  RunVisuallyComplete(test);
-  RunImageHash(test);
+  if (!test._noScreenshots) {
+    RunVisuallyComplete(test);
+    RunImageHash(test);
+  }
 
   WptTrace(loglevel::kFunction, 
             _T("[wptdriver] WptDriverCore::BrowserTest done\n"));

--- a/agent/wptdriver/wpt_settings.cc
+++ b/agent/wptdriver/wpt_settings.cc
@@ -84,7 +84,8 @@ WptSettings::WptSettings(WptStatus &status):
   ,_software_update(status)
   ,_requireValidCertificate(true)
   ,_webdriver_supported(false)
-  ,_reboot_on_lock_screen(false) {
+  ,_reboot_on_lock_screen(false)
+  ,_dontCleanupResults(true) {
 }
 
 /*-----------------------------------------------------------------------------
@@ -221,6 +222,14 @@ bool WptSettings::Load(void) {
     _T("WebPageTest"), _T("Hawk"), _T(""), buff, _countof(buff), iniFile)) {
     _hawk_command = buff;
     _hawk_command.Trim(_T("\""));
+  }
+  
+  if (GetPrivateProfileString(
+    _T("WebPageTest"), _T("DontCleanupResults"), _T(""), buff, _countof(buff), iniFile)) {
+    _dontCleanupResults = true;
+  }
+  else {
+    _dontCleanupResults = false;
   }
 
   if (_webdriver_supported) {

--- a/agent/wptdriver/wpt_settings.h
+++ b/agent/wptdriver/wpt_settings.h
@@ -138,6 +138,7 @@ public:
   CString _webdriver_server_url;
   CString _imagetools_command;
   CString _hawk_command;
+  bool _dontCleanupResults;
   bool _webdriver_supported;
   bool _reboot_on_lock_screen;
 };

--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -111,6 +111,7 @@ void WptTest::Reset(void) {
   _netlog = false;
   _video = false;
   _useHawk = false;
+  _noScreenshots = false;
   _spdy3 = false;
   _noscript = false;
   _clear_certs = false;
@@ -343,9 +344,13 @@ bool WptTest::Load(CString& test) {
   if (_script.GetLength()) {
     _test_timeout *= _script_timeout_multiplier;
 
-    // check if we use hawk for script capture. This information is passed as an in-script metadata
-    _useHawk = RegexSearch((LPCSTR)CT2A(_script), CStringA(_T("UseHawk\\s*:\\s*true")));
-    WptTrace(loglevel::kFunction, _T("WptTest::Load() - use hawk screenshots %d"), _useHawk);
+    _noScreenshots = RegexSearch((LPCSTR)CT2A(_script), CStringA(_T("NoScreenshots\\s*:\\s*true")));
+    WptTrace(loglevel::kFunction, _T("WptTest::Load() - override to turn off all screenshots %d"), _noScreenshots);
+    if (!_noScreenshots) {
+      // check if we use hawk for script capture. This information is passed as an in-script metadata
+      _useHawk = RegexSearch((LPCSTR)CT2A(_script), CStringA(_T("UseHawk\\s*:\\s*true")));
+      WptTrace(loglevel::kFunction, _T("WptTest::Load() - use hawk screenshots %d"), _useHawk);
+    }
   }
 
   WptTrace(loglevel::kFunction, _T("WptTest::Load() - Loaded test %s\n"), 

--- a/agent/wptdriver/wpt_test.cc
+++ b/agent/wptdriver/wpt_test.cc
@@ -112,6 +112,7 @@ void WptTest::Reset(void) {
   _video = false;
   _useHawk = false;
   _noScreenshots = false;
+  _noLockstep = false;
   _spdy3 = false;
   _noscript = false;
   _clear_certs = false;
@@ -351,6 +352,7 @@ bool WptTest::Load(CString& test) {
       _useHawk = RegexSearch((LPCSTR)CT2A(_script), CStringA(_T("UseHawk\\s*:\\s*true")));
       WptTrace(loglevel::kFunction, _T("WptTest::Load() - use hawk screenshots %d"), _useHawk);
     }
+    _noLockstep = RegexSearch((LPCSTR)CT2A(_script), CStringA(_T("NoLockstep\\s*:\\s*true")));
   }
 
   WptTrace(loglevel::kFunction, _T("WptTest::Load() - Loaded test %s\n"), 

--- a/agent/wptdriver/wpt_test.h
+++ b/agent/wptdriver/wpt_test.h
@@ -160,6 +160,7 @@ public:
   bool    _trace;
   bool    _netlog;
   bool    _useHawk;
+  bool    _noScreenshots;
   bool    _video;
   bool    _spdy3;
   bool    _noscript;

--- a/agent/wptdriver/wpt_test.h
+++ b/agent/wptdriver/wpt_test.h
@@ -161,6 +161,7 @@ public:
   bool    _netlog;
   bool    _useHawk;
   bool    _noScreenshots;
+  bool    _noLockstep;
   bool    _video;
   bool    _spdy3;
   bool    _noscript;

--- a/agent/wpthook/test_state.cc
+++ b/agent/wpthook/test_state.cc
@@ -306,7 +306,7 @@ void TestState::OnLoad() {
     QueryPerformanceCounter(&_on_load);
     GetCPUTime(_doc_cpu_time, _doc_total_time);
     ActivityDetected();
-    if (!_test._useHawk) {
+    if (!_test._useHawk && !_test._noScreenshots) {
       _screen_capture.Capture(_frame_window, CapturedImage::DOCUMENT_COMPLETE);
     }
     _current_document = 0;
@@ -436,7 +436,7 @@ BOOL CALLBACK MakeTopmost(HWND hwnd, LPARAM lParam) {
 Capture session result image
 -----------------------------------------------------------------------------*/
 void TestState::GrabResultScreenshot() {
-  if (!_test._useHawk) {
+  if (!_test._useHawk && !_test._noScreenshots) {
     _screen_capture.Capture(_frame_window, CapturedImage::RESULT);
   }
 }
@@ -497,7 +497,7 @@ void TestState::UpdateBrowserWindow() {
     Grab a video frame if it is appropriate
 -----------------------------------------------------------------------------*/
 void TestState::GrabVideoFrame(bool force) {
-  if (!_test._useHawk && _active && _frame_window && (force || received_data_)) {
+  if (!_test._useHawk && !_test._noScreenshots && _active && _frame_window && (force || received_data_)) {
     // use a falloff on the resolution with which we capture video
     bool grab_video = false;
     LARGE_INTEGER now;
@@ -935,7 +935,7 @@ void TestState::ResizeBrowserForResponsiveTest() {
   browser-specific extensions
 -----------------------------------------------------------------------------*/
 void TestState::CheckResponsive() {
-  if (!_test._useHawk && _frame_window) {
+  if (!_test._useHawk && !_test._noScreenshots && _frame_window) {
     _screen_capture.Capture(_frame_window, CapturedImage::RESPONSIVE_CHECK,
                             false);
   }


### PR DESCRIPTION
3 new configuration parameters for debugging:

In wptdriver.ini:
- "DontCleanupResults=true" turns off deletion of the results directory after a test is completed. It does not turn off results deletion at the beginning of a new test.

In the script metadata
- "NoScreenshots: true" turns off all screenshots (wpthook or hawk)
- "NoLockstep: true" turns off lock step mode in the rwdclient
